### PR TITLE
enable hxl proxy to run under url paths

### DIFF
--- a/hxl-proxy.wsgi.TEMPLATE
+++ b/hxl-proxy.wsgi.TEMPLATE
@@ -37,4 +37,17 @@ os.environ['HXL_PROXY_CONFIG'] = '/path/config.py'
 
 from hxl_proxy import app as application
 
+# run it under a different url path than /
+# 1. configure nginx
+# location ^~ /hxlproxy {
+#     proxy_pass          http://<hxl_proxy_ip>:<hxl_proxy_port>;
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Scheme $scheme;
+#     proxy_set_header X-Script-Name /<hxl_proxy_url_path>;
+# }
+# 2. uncomment the 2 lines below
+#from <your path to reverse_proxied.py> import reverse_proxied as rp
+#application.wsgi_app = rp.ReverseProxied(application.wsgi_app)
+
 # end

--- a/hxl-proxy.wsgi.TEMPLATE
+++ b/hxl-proxy.wsgi.TEMPLATE
@@ -40,7 +40,7 @@ from hxl_proxy import app as application
 # run it under a different url path than /
 # 1. configure nginx
 # location ^~ /myprefix {
-#     proxy_pass          http://<hxl_proxy_ip>:<hxl_proxy_port>;
+#     proxy_pass       http://<hxl_proxy_ip>:<hxl_proxy_port>;
 #     proxy_set_header Host $host;
 #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #     proxy_set_header X-Scheme $scheme;

--- a/hxl-proxy.wsgi.TEMPLATE
+++ b/hxl-proxy.wsgi.TEMPLATE
@@ -39,15 +39,15 @@ from hxl_proxy import app as application
 
 # run it under a different url path than /
 # 1. configure nginx
-# location ^~ /hxlproxy {
+# location ^~ /myprefix {
 #     proxy_pass          http://<hxl_proxy_ip>:<hxl_proxy_port>;
 #     proxy_set_header Host $host;
 #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #     proxy_set_header X-Scheme $scheme;
-#     proxy_set_header X-Script-Name /<hxl_proxy_url_path>;
+#     proxy_set_header X-Script-Name /myprefix;
 # }
 # 2. uncomment the 2 lines below
-#from <your path to reverse_proxied.py> import reverse_proxied as rp
+#from <path_to_reverse_proxied.py> import reverse_proxied as rp
 #application.wsgi_app = rp.ReverseProxied(application.wsgi_app)
 
 # end

--- a/reverse_proxied.py
+++ b/reverse_proxied.py
@@ -1,0 +1,44 @@
+"""implement a simple url path improvement to a wsgi app.
+
+got from http://flask.pocoo.org/snippets/35/
+Thanks to Peter Hansen.
+"""
+
+
+class ReverseProxied(object):
+    """implement utl path feature in wsgi.
+
+    Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    :param app: the WSGI application
+    """
+
+    def __init__(self, app):
+        """initialize."""
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        """call."""
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        return self.app(environ, start_response)


### PR DESCRIPTION
The example is only for nginx.

Warning: the main redirect (from ```/``` to ```/data/source```) doesn't seem to work with this.

However, if you navigate to /myprefix/data/source, all seems to work.
