### PR TITLE
Added a max_rows parameter to limit number of rows returned, per #134

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 	- &force=on works for input as well as output
 	- limit HTML table display to 5,000 rows to avoid timeouts (full
 	  dataset still available via CSV or JSON download)
+	- add a max_rows parameter to limit the number of rows returned.
 
 2016-08-30 Release 0.6
 	- Add support for requests-cache, so that different views of the same

--- a/hxl_proxy/static/hxl-proxy/hxl-proxy.js
+++ b/hxl_proxy/static/hxl-proxy/hxl-proxy.js
@@ -177,7 +177,7 @@ hxl_proxy.ui.form = function() {
         filter_class = ".fields-" + filter_name;
         filter_title = (filter_desc ? filter_desc : '(not set)');
         if (filter_title == '(none)') {
-            filter_title = "(add new step)";
+            filter_title = "(add new filter)";
         }
         $(node).find(".modal-title").text(filter_title);
 

--- a/hxl_proxy/templates/data-recipe.html
+++ b/hxl_proxy/templates/data-recipe.html
@@ -21,7 +21,7 @@
         {% include "includes/source.html" %}
       </div>
       <section id="filters" class="col-sm-4 col-md-3">
-        <h3>Recipe steps</h3>
+        <h3>Recipe filters</h3>
         {% if recipe.recipe_id %}
         {% set method="POST" %}
         {% set action="/actions/save-recipe" %}
@@ -103,18 +103,31 @@
                   </div>
                 </div>
               </div>
-              <div class="row small">
-                <div class="form-group col-md-12">
-                  <label for="stub">Download filename (without ext)</label>
-                  <input name="stub" class="form-control" value="{{ recipe.stub|nonone }}" placeholder="data-filename" />
+              <div class="row">
+                <div class="form-group col-md-6">
+                  <label for="stub">Filename (no ext)</label>
+                  <input name="stub"
+                         class="form-control"
+                         value="{{ recipe.stub|nonone }}"
+                         placeholder="data"
+                         title="Base filename for download, without .csv or .json extension"
+                         />
                 </div>
-                <label>
-                  
-                </label>
+                <div class="form-group col-md-6">
+                  <label for="max_rows">Max rows</label>
+                  <input name="max_rows"
+                         type="number"
+                         min="0"
+                         step="1"
+                         class="form-control"
+                         value="{{ recipe.args.max_rows|nonone }}"
+                         placeholder="nnnn"
+                         title="Maximum rows of data to display or download"
+                         />
+                </div>
               </div>
               <div class="form-input">
-                <button class="btn btn-info btn-xs">Update preferences</button>
-                <a class="btn btn-success btn-xs pull-right" href="{{ data_url(recipe) }}">Done filters</a>
+                <button class="btn btn-info btn-sm">Update preferences</button>
               </div>
             </div>
           </fieldset>

--- a/hxl_proxy/templates/data-view.html
+++ b/hxl_proxy/templates/data-view.html
@@ -51,11 +51,19 @@
           <strong>Note:</strong> Showing only the first {{
           "{:,}".format(source.max_rows) }} data rows. Download the
           CSV or JSON for the full dataset.
+          {% if recipe.args.max_rows %}
+          (Limited to maximum {{ recipe.args.max_rows }} row(s) by the
+          <i>max_rows</i> parameter.)
+          {% endif %}
         </div>
         <div id="post-preview-warning" class="alert alert-warning">
           <strong>Note:</strong> Showing only the first {{
           "{:,}".format(source.max_rows) }} data rows. Download the
           CSV or JSON for the full dataset.
+          {% if recipe.args.max_rows %}
+          (Limited to maximum {{ recipe.args.max_rows }} row(s) by the
+          <i>max_rows</i> parameter.)
+          {% endif %}
         </div>
         {% endif %}
       </section>


### PR DESCRIPTION
With max_rows=0, only the headers and hashtags will be returned, even
in a CSV or JSON download.