### PR TITLE
Add support for &recipe parameter per #136

### DIFF
--- a/hxl_proxy/filters.py
+++ b/hxl_proxy/filters.py
@@ -30,6 +30,10 @@ def setup_filters(recipe):
     # Basic input source
     source = hxl.data(make_tagged_input(recipe['args']))
 
+    # Do we have a JSON recipe? Load it first.
+    if recipe['args'].get('recipe'):
+        source = source.recipe(recipe['args'].get('recipe'))
+
     # Intercept missing hashtags here
     try:
         source.columns


### PR DESCRIPTION
The Proxy will parse the JSON recipe first (format documented in
https://github.com/HXLStandard/hxl-proxy/wiki/JSON-recipes) then will
append any form-based filters.