### PR TITLE
About Page: Update Docker Hub link to the official unocha/hxl-proxy

### DIFF
--- a/hxl_proxy/templates/about.html
+++ b/hxl_proxy/templates/about.html
@@ -90,7 +90,7 @@
             Proxy web application on your personal computer, or on an
             Intranet inside your organisation's firewall. There is a
             <a
-                href="https://hub.docker.com/r/teodorescuserban/hxl-proxy/">Docker
+                href="https://hub.docker.com/r/unocha/hxl-proxy">Docker
             image</a> available for fast deployment.
           </li>
         </ol>


### PR DESCRIPTION
This one-liner pull request update the About page reference of Docker Hub image from <https://hub.docker.com/r/unocha/hxl-proxy> (current images) from the <https://hub.docker.com/r/teodorescuserban/hxl-proxy/> (3 years old)


![Captura de tela de 2020-04-12 12-56-09](https://user-images.githubusercontent.com/812299/79074234-9e9f6500-7cc1-11ea-828d-e2bc9daddb03.png)
