### PR TITLE
test: Ensure the tests run against the software we use on dev/stage and prod, not placeholders.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Spinning up container
         run: |
           docker-compose -f docker-compose-github-actions.yml up -d
-          sleep 5
-          docker-compose -f docker-compose-github-actions.yml exec -T proxy sh -c "ln -s /srv/config/schema-sqlite3.sql /srv/www/hxl_proxy/schema-sqlite3.sql"
+          sleep 10
+          docker-compose -f docker-compose-github-actions.yml exec -T proxy sh -c "ln -s /srv/config/schema-mysql.sql /srv/www/hxl_proxy/schema-mysql.sql"
           docker-compose -f docker-compose-github-actions.yml exec -T proxy sh -c "python3 setup.py install"
       - name: Running tests
         run: docker-compose -f docker-compose-github-actions.yml exec -T proxy sh -c "python3 setup.py test"

--- a/config.py.TEMPLATE
+++ b/config.py.TEMPLATE
@@ -94,6 +94,9 @@ ITOS_CACHE_TIMEOUT = 604800
 # 'sqlite3' or 'mysql'
 DB_TYPE=os.getenv('DB_TYPE', 'sqlite3')
 
+# Schema file, for tests.
+DB_SCHEMA_FILE = os.getenv('DB_SCHEMA_FILE', 'schema-sqlite3.sql')
+
 # SQLite3 settings
 DB_FILE='/tmp/hxl-proxy.db'
 

--- a/docker-compose-github-actions.yml
+++ b/docker-compose-github-actions.yml
@@ -4,28 +4,32 @@ services:
   mysql:
     image: public.ecr.aws/unocha/mysql:10.6
     hostname: mysql
+    container_name: hxl-proxy-mysql
     environment:
-      - MYSQL_DB=hxl_proxy
-      - MYSQL_USER=hxl_proxy
-      - MYSQL_PASS=hxl_proxy
+      MYSQL_DB: hxl_proxy
+      MYSQL_USER: hxl_proxy
+      MYSQL_PASS: hxl_proxy
 
   redis:
     image: public.ecr.aws/unocha/redis:5
     hostname: redis
+    container_name: hxl-proxy-redis
 
   proxy:
+    container_name: hxl-proxy
     build: ./
     ports:
       - "127.0.0.1:5000:5000"
     entrypoint: "tail -f /dev/null"
     working_dir: /srv/www
     environment:
-      DB_TYPE: mysql
-      DB_HOST: mysql
-      DB_DATABASE: hxl_proxy
-      DB_PORT: 3306
-      DB_USERNAME: hxl_proxy
-      DB_PASSWORD: hxl_proxy
+      HXL_PROXY_CONFIG: /srv/config/config.py
       DB_SCHEMA_FILE: schema-mysql.sql
+      DB_TYPE: mysql
+      MYSQL_HOST: mysql
+      MYSQL_DB: hxl_proxy
+      DB_PORT: 3306
+      MYSQL_USER: hxl_proxy
+      MYSQL_PASS: hxl_proxy
       CACHE_TYPE: redis
       CACHE_REDIS_URL: redis://redis:6379/1

--- a/docker-compose-github-actions.yml
+++ b/docker-compose-github-actions.yml
@@ -1,9 +1,31 @@
 version: '2.2'
 
 services:
+  mysql:
+    image: public.ecr.aws/unocha/mysql:10.6
+    hostname: mysql
+    environment:
+      - MYSQL_DB=hxl_proxy
+      - MYSQL_USER=hxl_proxy
+      - MYSQL_PASS=hxl_proxy
+
+  redis:
+    image: public.ecr.aws/unocha/redis:5
+    hostname: redis
+
   proxy:
     build: ./
     ports:
-      - "0.0.0.0:5000:5000"
+      - "127.0.0.1:5000:5000"
     entrypoint: "tail -f /dev/null"
     working_dir: /srv/www
+    environment:
+      DB_TYPE: mysql
+      DB_HOST: mysql
+      DB_DATABASE: hxl_proxy
+      DB_PORT: 3306
+      DB_USERNAME: hxl_proxy
+      DB_PASSWORD: hxl_proxy
+      DB_SCHEMA_FILE: schema-mysql.sql
+      CACHE_TYPE: redis
+      CACHE_REDIS_URL: redis://redis:6379/1

--- a/hxl_proxy/dao.py
+++ b/hxl_proxy/dao.py
@@ -30,7 +30,9 @@ import hxl_proxy
 class db:
     """Low-level database functions"""
 
-    TEST_SCHEMA_FILE = os.path.join(os.path.dirname(__file__), 'schema-sqlite3.sql')
+    schema_file = hxl_proxy.app.config.get('DB_SCHEMA_FILE', 'schema-sqlite3.sql')
+
+    TEST_SCHEMA_FILE = os.path.join(os.path.dirname(__file__), schema_file)
     """The filename of the SQL schema."""
 
     type = hxl_proxy.app.config.get('DB_TYPE', 'sqlite3')


### PR DESCRIPTION
Added a mariadb 10.6 and redis 5 container to the test stack, made a minor change to allow the test stack to load the correct schema file, configured the tests to run with redis and mariadb.
 
Note that the database tests fail, because the API differs. MySQL apparently has no `executescript`.