### PR TITLE
Deactivate SIGALRM to temporarily fix timeout errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2023-03-29 Release 1.28.1
+	- temporarily deactivate Python-layer timeout (causing random request failures)
+
 2023-03-20 Release 1.28
 	- remove controller support for adding or editing saved recipes
 	- request code stops running after a configurable timeout (default: 30 seconds)

--- a/hxl_proxy/__init__.py
+++ b/hxl_proxy/__init__.py
@@ -8,7 +8,7 @@ Documentation: http://hxlstandard.org
 
 """
 
-__version__="1.28"
+__version__="1.28.1"
 """Module version number
 See https://www.python.org/dev/peps/pep-0396/
 

--- a/hxl_proxy/controllers.py
+++ b/hxl_proxy/controllers.py
@@ -36,7 +36,7 @@ def handle_alarm_signal(signum, frame):
     logup('Request timed out', level='info')
     raise TimeoutError()
 
-signal.signal(signal.SIGALRM, handle_alarm_signal)
+# signal.signal(signal.SIGALRM, handle_alarm_signal) # temporarily deactivated
 
 
 
@@ -187,7 +187,7 @@ def before_request():
         timeout = int(app.config.get('TIMEOUT', 30))
     except ValueError:
         timeout = 30
-    signal.alarm(timeout)
+    # signal.alarm(timeout) # temporarily deactivated
     
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     name = 'hxl-proxy',
     packages = ['hxl_proxy'],
     package_data={'hxl_proxy': ['*.sql']},
-    version = "1.28",
+    version = "1.28.1",
     description = 'Flask-based web proxy for HXL',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -94,8 +94,9 @@ class AbstractControllerTest(base.AbstractDBTest):
 
 class TestTimeout(AbstractControllerTest):
 
+    # temporarily deactivated
     @patch(URL_MOCK_TARGET, new=URL_MOCK_OBJECT)
-    def test_timeout(self):
+    def x_test_timeout(self):
         """ Confirm that a time returns a 408 error """
 
         # Use a sting to ensure conversion is working


### PR DESCRIPTION
Deactivate Python-level timeout with SIGALRM fixes #HXL-40

Prepare 1.28.1 release (not yet on PyPi)